### PR TITLE
updated logger package, dart version, and lint fixes

### DIFF
--- a/bin/main.dart
+++ b/bin/main.dart
@@ -1,7 +1,4 @@
-import 'dart:io';
-
 import 'package:pubspec_dependency_sorter/pubspec_dependency_sorter.dart';
-
 
 void main(List<String> args) {
   pubsecDependencySorter(args: args);

--- a/bin/pubspec_dependency_sorter.dart
+++ b/bin/pubspec_dependency_sorter.dart
@@ -57,7 +57,7 @@ main(List<String> args) async {
         SplayTreeMap<String, DependencyReference>.from(
       dependencyOverrides,
     );
-    logger.i("<<<---- sorted dependency overides.");
+    logger.i("<<<---- sorted dependency overrides.");
     // change the dependencies and dependency overides
     var newPubSpec = pubSpec.copy(
         dependencies: sortDependenciesByValue,
@@ -66,9 +66,10 @@ main(List<String> args) async {
 
     // save it
     await newPubSpec.save(myDirectory);
-    logger.v("Saved the changes");
+    logger.i("Saved the changes");
 
-    logger.wtf("Done---< please star and like the package. https://github.com/Genialngash/pubspec-dependency-sorter >");
+    logger.i(
+        "Done---< please star and like the package. https://github.com/Genialngash/pubspec-dependency-sorter >");
   } catch (e) {
     logger.e(e);
   }

--- a/lib/pubspec_dependency_sorter.dart
+++ b/lib/pubspec_dependency_sorter.dart
@@ -66,9 +66,10 @@ pubsecDependencySorter({required List<String> args}) async {
 
     // save it
     await newPubSpec.save(myDirectory);
-    logger.v("Saved the changes");
+    logger.i("Saved the changes");
 
-    logger.wtf("Done---< please star and like the package. https://github.com/Genialngash/pubspec-dependency-sorter >");
+    logger.i(
+        "Done---< please star and like the package. https://github.com/Genialngash/pubspec-dependency-sorter >");
   } catch (e) {
     logger.e(e);
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,13 +1,13 @@
 name: pubspec_dependency_sorter
-version: 1.0.3
+version: 1.0.4
 Author: Danche Nganga <ngangadanche@gmail.com>
 homepage: https://github.com/danchengash/pubspec-dependency-sorter
 description: helps sort flutter,dart pubspec.yaml dependecies alphabetically.
 environment: 
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.17.0 <4.0.0'
   # flutter: '>=1.17.0'
 dependencies: 
-  logger: ^1.1.0
+  logger: ^2.0.1
   pubspec: ^2.3.0
   flutter: 
     sdk: flutter


### PR DESCRIPTION
updated logger package to `2.0.1`
updated Dart version range to `>=2.17.0 <4.0.0`
removed unused import
changed deprecated logger usages of `.v` and `.wtf`